### PR TITLE
Add load event

### DIFF
--- a/mobius.js
+++ b/mobius.js
@@ -38,7 +38,7 @@ if (/WebKit/i.test(navigator.userAgent)) { // sniff
 }
 
 /* for other browsers */
-window.onload = init;
+addLoadEvent(init);
 
 
 function addLoadEvent(func) {
@@ -51,18 +51,6 @@ var oldonload = window.onload;
      func();
       }
    }
-}
-
-function addLoadEvent(func) {
-  var oldonload = window.onload;
-  if (typeof window.onload != 'function') {
-    window.onload = func;
-  } else {
-    window.onload = function() {
-      oldonload();
-      func();
-    }
-  }
 }
 
 

--- a/mobius.js
+++ b/mobius.js
@@ -23,19 +23,20 @@ function init() {
 };
 
 /* for Mozilla/Opera9 */
-if (document.addEventListener) {
-    document.addEventListener("DOMContentLoaded", init, false);
-}
-
+/* if (document.addEventListener) {
+*    document.addEventListener("DOMContentLoaded", init, false);
+*}
+*/
 
 /* for Safari */
-if (/WebKit/i.test(navigator.userAgent)) { // sniff
-    var _timer = setInterval(function() {
-        if (/loaded|complete/.test(document.readyState)) {
-            init(); // call the onload handler
-        }
-    }, 10);
-}
+/*if (/WebKit/i.test(navigator.userAgent)) { // sniff
+*    var _timer = setInterval(function() {
+*        if (/loaded|complete/.test(document.readyState)) {
+*            init(); // call the onload handler
+*        }
+*    }, 10);
+*}
+*/
 
 /* for other browsers */
 // addLoadEvent(init);

--- a/mobius.js
+++ b/mobius.js
@@ -38,7 +38,7 @@ if (/WebKit/i.test(navigator.userAgent)) { // sniff
 }
 
 /* for other browsers */
-addLoadEvent(init);
+// addLoadEvent(init);
 
 
 function addLoadEvent(func) {


### PR DESCRIPTION
Changed function call to "init" in mobius.js to accommodate multiple onload functions.

Also deleted redundant copy of AddLoadEvent.